### PR TITLE
Correctly report deploy errors

### DIFF
--- a/Scripts/DeployToEnvironment.ps1
+++ b/Scripts/DeployToEnvironment.ps1
@@ -124,13 +124,15 @@ $startEpiDeploymentSplat = @{
     ProjectId = "$ProjectID"
     Wait = $false
     TargetEnvironment = "$TargetEnvironment"
-    UseMaintenancePage = $UseMaintenancePage
     ClientSecret = "$ClientSecret"
     ClientKey = "$ClientKey"
 }
 
 if($DirectDeploy -eq $true){
     $startEpiDeploymentSplat.Add("DirectDeploy", $true)
+}
+if($UseMaintenancePage -eq $true){
+    $startEpiDeploymentSplat.Add("UseMaintenancePage", $true)
 }
 
 
@@ -199,10 +201,14 @@ start-sleep -Milliseconds 1000
 #If the status is set to Failed, throw an error
 if($status -eq "Failed"){
     Write-Output "##vso[task.complete result=Failed;]"
-    throw "Deployment Failed. Errors: \n" + $deploy.deploymentErrors
+    $errors = $currDeploy | Select -ExpandProperty deploymentErrors
+    throw "Deployment Failed. Errors: \n" + $errors
 }
 
+#Get links for validation
+$validationLinks = $currDeploy | Select -ExpandProperty validationLinks
 Write-Host "Deployment Complete"
+Write-Host "Please verify at $validationLinks"
 
 #Set the Output variable for the Deployment ID, if needed
 Write-Output "##vso[task.setvariable variable=DeploymentId;]'$deployId'"

--- a/Scripts/PromoteToEnvironment.ps1
+++ b/Scripts/PromoteToEnvironment.ps1
@@ -141,11 +141,13 @@ $startEpiDeploymentSplat = @{
 
 if($IncludeCode){
     $startEpiDeploymentSplat.Add("SourceApp", $SourceApp)
-    $startEpiDeploymentSplat.Add("UseMaintenancePage", $UseMaintenancePage)
 }
 
 if($DirectDeploy -eq $true){
     $startEpiDeploymentSplat.Add("DirectDeploy", $true)
+}
+if($UseMaintenancePage -eq $true){
+    $startEpiDeploymentSplat.Add("UseMaintenancePage", $true)
 }
 
 if(![string]::IsNullOrWhiteSpace($ZeroDownTimeMode)){
@@ -212,7 +214,8 @@ start-sleep -Milliseconds 1000
 
 #If the status is set to Failed, throw an error
 if($status -eq "Failed"){
-    throw "Deployment Failed. Errors: \n" + $deploy.deploymentErrors
+    $errors = $currDeploy | Select -ExpandProperty deploymentErrors
+    throw "Deployment Failed. Errors: \n" + $errors
 }
 
 Write-Host "Deployment Complete"


### PR DESCRIPTION
When the deploy encounters errors, it seems that these are not stored in the $deploy object, but rather the most recent $currDeploy iteration. Also, this property should be expanded in the same way we handle validation links. 